### PR TITLE
Chore sfdx generator 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-sourcemaps": "^0.4.2",
     "semantic-release": "^15.9.15",
-    "sfdx-generator": "1.0.0",
+    "sfdx-generator": "2.0.0",
     "sfdx-prebuilt": "5.9.4",
     "ts-jest": "^23.1.4",
     "ts-node": "^7.0.1",

--- a/src/core/responseParser.ts
+++ b/src/core/responseParser.ts
@@ -7,7 +7,7 @@ export class ResponseParser {
     response = this.sanitizeResponse(response);
 
     // If the response is blank, it means there is nothing to parse. Return undefined.
-    if (response === undefined || _.isEmpty(response)) {
+    if (_.isEmpty(response)) {
       return undefined;
     }
 
@@ -22,7 +22,7 @@ export class ResponseParser {
   }
 
   private sanitizeResponse(response: string) {
-    if (response === undefined) {
+    if (_.isEmpty(response)) {
       return response;
     }
 

--- a/src/core/responseParser.ts
+++ b/src/core/responseParser.ts
@@ -1,7 +1,7 @@
 import * as _ from "underscore";
 
 export class ResponseParser {
-  public parse<T>(response: string): T | string | undefined {
+  public parse<T>(response: string | undefined = ""): T | string | undefined {
     // For now it's realllly easy, but maybe someday we'll have to remove some stuff or handle more complex stuff.
     let returnValue: T | string;
     response = this.sanitizeResponse(response);

--- a/test/core/commandBuilder.test.ts
+++ b/test/core/commandBuilder.test.ts
@@ -1,13 +1,12 @@
-import { CommandBuilder } from "../../src/core/commandBuilder";
 import { ICommandRunner } from "../../src/core/commandRunner";
-import { ICommandExecutioner, CommandExecutioner } from "../../src/core/commandExecutioner";
+import { CommandExecutioner } from "../../src/core/commandExecutioner";
 import { Apex } from "../../src/generated/apex";
 import { Config } from "../../src/generated/config";
 import { Auth } from "../../src/generated/auth";
 
 describe("Can create commands", () => {
-  let commandRunnerMock;
-  let commandRunnerMockImpl;
+  let commandRunnerMock: jest.Mock<ICommandRunner>;
+  let commandRunnerMockImpl: ICommandRunner;
   let commandExecutioner: CommandExecutioner;
 
   // APIs

--- a/test/core/responseParser.test.ts
+++ b/test/core/responseParser.test.ts
@@ -41,8 +41,18 @@ describe("Can parse commands", () => {
     expect(response).toBe(undefined);
   });
 
-  it("new line input", () => {
+  it("New line input", () => {
     const response = responseParser.parse<any>("\n");
     expect(response).toBe(undefined);
+  });
+
+  it("Bad json input", () => {
+    const badJson = "{{}";
+    jest.spyOn(global.console, "log").mockImplementation(msg => {
+      expect(msg).toContain("Cannot parse");
+    });
+
+    const response = responseParser.parse<any>(badJson);
+    expect(response).toBe(badJson);
   });
 });

--- a/tools/generate-files.js
+++ b/tools/generate-files.js
@@ -1,15 +1,15 @@
-var generator = require('sfdx-generator')
-var path = require('path')
-var root = path.resolve(__dirname, './..')
-var generator = new generator.Generator({
+const sfdxGenerator = require('sfdx-generator');
+const path = require('path');
+const root = path.resolve(__dirname, './..');
+const generator = new sfdxGenerator.Generator({
   SFDXPath: 'sfdx',
-  outputDirectory: path.resolve(root, 'src/generated'),
+  outputDirectory: path.resolve(root, './src/generated'),
   templateDirectory: path.resolve(root, './tools/templates'),
-  fileExtension: 'ts'
+  fileExtension: '.ts'
 });
 
-var commandFile = require('../commands.json')
-var stringFile = JSON.stringify(commandFile)
+const commandFile = require('../commands.json');
+const stringFile = JSON.stringify(commandFile);
 generator.generate(stringFile).then(() => {
-  console.log('Generating done')
-})
+  console.log('Generating done');
+});


### PR DESCRIPTION
- Bumps sfdx generator version to 2.0.0
- Uses const in generate-files.js and changes extension format (new since 2.0.0)

Also, when running the tests, I stubble upon some undeclared types (when running the prepush). I fixed them and remove some unused imports.