### PR TITLE
feat(errorhandling): don't fail if there's only warnings

### DIFF
--- a/test/core/requestExecutioner.test.ts
+++ b/test/core/requestExecutioner.test.ts
@@ -1,6 +1,8 @@
 import { CommandExecutioner } from "../../src/core/commandExecutioner";
 import { CommandRunner, ICommandRunnerOptions } from "../../src/core/commandRunner";
-import { EOL } from "os";
+import { EOL, platform } from "os";
+import exec from "child_process";
+
 describe("Can create commands", () => {
   it("CommandExecutioner is instantiable", () => {
     let commandRunner = new CommandRunner();
@@ -19,5 +21,35 @@ describe("Can return the output of the command", () => {
     let commandRunner = new CommandRunner(mockedCommandRunnerOptions);
     expect(await commandRunner.runCommand("echo boop")).toBe("boop" + EOL);
     expect(fakeInfo).toBeCalledWith("boop" + EOL);
+  });
+
+  it("Should not fail if there's only warning in the stderr", async () => {
+    let fakeInfo = jest.fn();
+    const mockedCommandRunnerOptions: ICommandRunnerOptions = {
+      sfdxPath: "",
+      useLiveLog: false
+    };
+    let commandRunner = new CommandRunner(mockedCommandRunnerOptions);
+    let payload = `{ "warnings": ["boop", "beep", "bop"] }`;
+    expect(
+      await commandRunner.runCommand(
+        `>&2 echo ${platform() === "win32" ? payload : payload.replace(/"/g, '\\"')}`
+      )
+    ).toContain("Completed with warnings");
+  });
+
+  it("Should fail if there's something else or more than a warning in the stderr", async () => {
+    let fakeInfo = jest.fn();
+    const mockedCommandRunnerOptions: ICommandRunnerOptions = {
+      sfdxPath: "",
+      useLiveLog: false
+    };
+    let commandRunner = new CommandRunner(mockedCommandRunnerOptions);
+    let payload = `{ "warnings": ["boop", "beep", "bop"], "errors": 42 }`;
+    expect(
+      commandRunner.runCommand(
+        `>&2 echo ${platform() === "win32" ? payload : payload.replace(/"/g, '\\"')}`
+      )
+    ).rejects.toEqual(payload + EOL);
   });
 });


### PR DESCRIPTION
### What is the issue?
Because now SFDX will _throw_ a warning about data collection on its first run, making the first command executed by a CLI or a user consistently fail.
But also, generally, I don't think we should fail if there's only warnings.

### What's the proposed fix?
Before rejecting the execution and sending an error, I proposed that we check in this order:
1. If there's no error object;
2. If the error stream, once parsed (we're always using `--json` so the output is always a JSON), contains only one key;
3. That this key is `warning`.

If all these conditions are satisfied, then we do not throw an error, but still, warn the user that there were some warnings.