### PR TITLE
feat(sancheck on entries): ensure that sfdxPath is not falsy

### DIFF
--- a/src/core/commandRunner.ts
+++ b/src/core/commandRunner.ts
@@ -51,9 +51,17 @@ export class CommandRunner implements ICommandRunner {
       // Execute the command. If there's an error thrown or the stderr is not empty, it will reject the promise.
       // Otherwise, it will resolve with the content of the stdout.
       let execProcess = exec(fullCommand, actualOptions, (error, stdout, stderr) => {
+        // If there's no error object and the error stream only contains some warning, keep going.
         if (error || stderr !== "") {
-          // If there's no error object and the error stream only contains some warning, keep going.
-          let stderrJSON = JSON.parse(stderr.trim());
+          let stderrJSON;
+          // Ensure that the error is in JSON format, for now, we won't deal with the case that the error is not a JSON.
+          // Mostly used for unit test for now and as a sanity check.
+          try {
+            stderrJSON = JSON.parse(stderr.trim());
+          } catch (error) {
+            return reject(error);
+          }
+
           if (
             !error &&
             Object.keys(stderrJSON).length === 1 &&

--- a/src/sfdx-js.ts
+++ b/src/sfdx-js.ts
@@ -25,7 +25,7 @@ export class Client extends GeneratedClient {
     SFDXPath: string,
     useLiveLog: boolean = false,
     customLogger: CustomLogger = console
-  ) {
+  ): Client {
     if (!SFDXPath) {
       console.warn("SFDX path is undefined/null, defaulting to sfdx");
       SFDXPath = "sfdx";

--- a/src/sfdx-js.ts
+++ b/src/sfdx-js.ts
@@ -26,6 +26,11 @@ export class Client extends GeneratedClient {
     useLiveLog: boolean = false,
     customLogger: CustomLogger = console
   ) {
+    if (!SFDXPath) {
+      console.warn("SFDX path is undefined/null, defaulting to sfdx");
+      SFDXPath = "sfdx";
+    }
+
     const commandRunner = new CommandRunner({
       sfdxPath: SFDXPath,
       useLiveLog: useLiveLog,

--- a/test/sfdx-js.test.ts
+++ b/test/sfdx-js.test.ts
@@ -1,7 +1,23 @@
 import { Client } from "../src/sfdx-js";
+import { rejects } from "assert";
 
 describe("Client Interface", () => {
   it("Client is instantiable", () => {
     expect(new Client()).toBeInstanceOf(Client);
+  });
+
+  describe("createUsingPath entry point", () => {
+    it("should default to sfdx as its path if the given path is falsy", async () => {
+      const falsyPaths = [null, ""];
+      await falsyPaths.forEach(async element => {
+        const client = Client.createUsingPath(element as string);
+        await expect(client.doc.commandsDisplay({ json: true })).resolves.not.toThrow();
+      });
+    });
+
+    it("should not default to sfdx as its path if the given path is truthy", async () => {
+      const client = Client.createUsingPath("boop");
+      await expect(client.doc.commandsDisplay({ json: true })).rejects.toThrow();
+    });
   });
 });


### PR DESCRIPTION
If sfdxpath is null or whatever, warn, then default on sfdx.
Solve #38 